### PR TITLE
Changed Netherlands Antilles into Curacao

### DIFF
--- a/sql/database.sql
+++ b/sql/database.sql
@@ -1715,7 +1715,7 @@ INSERT INTO `geo_country_reference` VALUES (147, 'Namibia', 'NA', 'NAM');
 INSERT INTO `geo_country_reference` VALUES (148, 'Nauru', 'NR', 'NRU');
 INSERT INTO `geo_country_reference` VALUES (149, 'Nepal', 'NP', 'NPL');
 INSERT INTO `geo_country_reference` VALUES (150, 'Netherlands', 'NL', 'NLD');
-INSERT INTO `geo_country_reference` VALUES (151, 'Netherlands Antilles', 'AN', 'ANT');
+INSERT INTO `geo_country_reference` VALUES (151, 'Curacao', 'CW', 'CUR');
 INSERT INTO `geo_country_reference` VALUES (152, 'New Caledonia', 'NC', 'NCL');
 INSERT INTO `geo_country_reference` VALUES (153, 'New Zealand', 'NZ', 'NZL');
 INSERT INTO `geo_country_reference` VALUES (154, 'Nicaragua', 'NI', 'NIC');


### PR DESCRIPTION
NA is no land anymore it dissolved into Curacao, AND  (SMX) St Maarten an (BES- Island) Saba+St Eustatius+Bonaire, all belonging to the Netherlands-Kingdom. But Aruba, Curacao and St Maarten are different compared to BES ISlands and have their own status as Country own Flag and own hymn.....
